### PR TITLE
Use `imagePullPolicy: Always` for the webapp

### DIFF
--- a/deploy/template/tutorial-web-app.yml
+++ b/deploy/template/tutorial-web-app.yml
@@ -69,7 +69,7 @@ objects:
           - name: SSO_ROUTE
             value: ${SSO_ROUTE}
           image: ${WEBAPP_IMAGE}:${WEBAPP_IMAGE_TAG}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           name: tutorial-web-app
           ports:
           - containerPort: 5001


### PR DESCRIPTION
This prevents re-installs picking up on an old image tag already on the node where the webapp is deployed