### PR TITLE
Add WALKTHROUGH_LOCATIONS param and env to the web app template

### DIFF
--- a/deploy/template/tutorial-web-app.yml
+++ b/deploy/template/tutorial-web-app.yml
@@ -33,6 +33,9 @@ parameters:
   - name: SSO_ROUTE
     description: Openshift SSO URL
     required: false
+  - name: WALKTHROUGH_LOCATIONS
+    description: A comma separated list of git repositories or paths to walkthrough directories
+    required: true
 objects:
 - apiVersion: v1
   kind: DeploymentConfig
@@ -68,6 +71,8 @@ objects:
             value: production
           - name: SSO_ROUTE
             value: ${SSO_ROUTE}
+          - name: WALKTHROUGH_LOCATIONS
+            value: ${WALKTHROUGH_LOCATIONS}
           image: ${WEBAPP_IMAGE}:${WEBAPP_IMAGE_TAG}
           imagePullPolicy: Always
           name: tutorial-web-app


### PR DESCRIPTION
There has been a change to the web app to use an environment var
for the locations of walkthroughs, instead of bundling them in with
the web app. This env var is called WALKTHROUGH_LOCATIONS.

If the env var is not set then there is a default value. However, we
should allow this value to be overridden in the operator.

This change allows the env var to be set by setting the
WALKTHROUGH_LOCATIONS param in the template.