### PR TITLE
Add webapp version to the status of the webapp cr

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -9,8 +9,9 @@ spec:
   template:
     path: "/home/tutorial-web-app-operator/deploy/template/tutorial-web-app.yml"
     parameters:
-      IMAGE: "quay.io/integreatly/tutorial-web-app"
-      IMAGE_TAG: "latest"
-      OAUTH_CLIENT_ID: "tutorial-web-app"
+      WEBAPP_IMAGE: "quay.io/integreatly/tutorial-web-app"
+      WEBAPP_IMAGE_TAG: "latest"
+      OPENSHIFT_OAUTHCLIENT_ID: "tutorial-web-app"
       OPENSHIFT_HOST: ""
       SSO_ROUTE: ""
+      WALKTHROUGH_LOCATIONS: "https://github.com/integr8ly/tutorial-web-app-walkthroughs.git"

--- a/pkg/apis/integreatly/v1alpha1/types.go
+++ b/pkg/apis/integreatly/v1alpha1/types.go
@@ -28,6 +28,7 @@ type WebAppSpec struct {
 
 type WebAppStatus struct {
 	Message string `json:"message"`
+	Version string `json:"version"`
 }
 
 type WebAppTemplate struct {

--- a/pkg/handlers/webhandler.go
+++ b/pkg/handlers/webhandler.go
@@ -7,6 +7,7 @@ import (
 
 	"errors"
 	"fmt"
+
 	"github.com/integr8ly/tutorial-web-app-operator/pkg/apis/integreatly/openshift"
 	"github.com/integr8ly/tutorial-web-app-operator/pkg/metrics"
 	"github.com/openshift/api/template/v1"
@@ -77,6 +78,7 @@ func (h *AppHandler) Delete(cr *v1alpha1.WebApp) error {
 
 func (h *AppHandler) SetStatus(msg string, cr *v1alpha1.WebApp) {
 	cr.Status.Message = msg
+	cr.Status.Version = cr.Spec.Template.Parameters["WEBAPP_IMAGE_TAG"]
 	sdk.Update(cr)
 }
 


### PR DESCRIPTION
Add the version of the webapp installed to the `WebApp` custom resource status field. 

## Verification Step
1. Run `make prepare`. 
2. Deploy the operator using the image `quay.io/jameelb/tutorial-web-app-operator:latest`
3. Ensure that a field `Version` is within the `Status` field with the correct version of the webapp installed by the operator. 