### PR TITLE
set the image and version in the deployment config object

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -9,8 +9,6 @@ spec:
   template:
     path: "/home/tutorial-web-app-operator/deploy/template/tutorial-web-app.yml"
     parameters:
-      WEBAPP_IMAGE: "quay.io/integreatly/tutorial-web-app"
-      WEBAPP_IMAGE_TAG: "latest"
       OPENSHIFT_OAUTHCLIENT_ID: "tutorial-web-app"
       OPENSHIFT_HOST: ""
       SSO_ROUTE: ""

--- a/deploy/template/tutorial-web-app.yml
+++ b/deploy/template/tutorial-web-app.yml
@@ -12,12 +12,6 @@ parameters:
     description: The OpenShift master/api host e.g. openshift.example.com:8443. If blank, mock data (and mock service URL params) will be used.
     displayName: OpenShift Host
     required: false
-  - name: WEBAPP_IMAGE
-    value: quay.io/integreatly/tutorial-web-app
-    required: true
-  - name: WEBAPP_IMAGE_TAG
-    value: master
-    required: true
   - name: FUSE_URL
     description: Mock URL for Fuse. Only used if OPENSHIFT_HOST is empty
     required: false
@@ -73,7 +67,7 @@ objects:
             value: ${SSO_ROUTE}
           - name: WALKTHROUGH_LOCATIONS
             value: ${WALKTHROUGH_LOCATIONS}
-          image: ${WEBAPP_IMAGE}:${WEBAPP_IMAGE_TAG}
+          image: quay.io/integreatly/tutorial-web-app:master
           imagePullPolicy: Always
           name: tutorial-web-app
           ports:

--- a/pkg/handlers/webhandler.go
+++ b/pkg/handlers/webhandler.go
@@ -19,6 +19,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	WebappVersion = "master"
+)
+
 func NewWebHandler(m *metrics.Metrics, osClient openshift.OSClient, factory ClientFactory) AppHandler {
 	return AppHandler{
 		metrics:                      m,
@@ -78,7 +82,7 @@ func (h *AppHandler) Delete(cr *v1alpha1.WebApp) error {
 
 func (h *AppHandler) SetStatus(msg string, cr *v1alpha1.WebApp) {
 	cr.Status.Message = msg
-	cr.Status.Version = cr.Spec.Template.Parameters["WEBAPP_IMAGE_TAG"]
+	cr.Status.Version = WebappVersion
 	sdk.Update(cr)
 }
 


### PR DESCRIPTION
Following from this [PR](https://github.com/integr8ly/apicurio-operator/pull/9#discussion_r241090048), the operator should decide the version that it installs and not the user.

The following changes removes the parameters `WEBAPP_IMAGE` and `WEBAPP_IMAGE_TAG` from the custom resource parameter and directly points the deployment config object to the correct image. The version in the `status` field of the custom resource should also reflect this installed version.

## Verification Steps

1. Run make prepare.
2. Deploy the operator using the image `quay.io/jameelb/tutorial-web-app-operator:latest`
3. Ensure that the tutorial web app is installed successfully and the installed version should be reflected in the `status.version` field in the custom resource.