### PR TITLE
Set default values for webapp and walkthoughs

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -12,4 +12,3 @@ spec:
       OPENSHIFT_OAUTHCLIENT_ID: "tutorial-web-app"
       OPENSHIFT_HOST: ""
       SSO_ROUTE: ""
-      WALKTHROUGH_LOCATIONS: "https://github.com/integr8ly/tutorial-web-app-walkthroughs.git"

--- a/deploy/template/tutorial-web-app.yml
+++ b/deploy/template/tutorial-web-app.yml
@@ -29,6 +29,7 @@ parameters:
     required: false
   - name: WALKTHROUGH_LOCATIONS
     description: A comma separated list of git repositories or paths to walkthrough directories
+    value: https://github.com/integr8ly/tutorial-web-app-walkthroughs.git#master
     required: true
 objects:
 - apiVersion: v1

--- a/deploy/template/tutorial-web-app.yml
+++ b/deploy/template/tutorial-web-app.yml
@@ -29,7 +29,7 @@ parameters:
     required: false
   - name: WALKTHROUGH_LOCATIONS
     description: A comma separated list of git repositories or paths to walkthrough directories
-    value: https://github.com/integr8ly/tutorial-web-app-walkthroughs.git#master
+    value: https://github.com/integr8ly/tutorial-web-app-walkthroughs.git#v1.1.0
     required: true
 objects:
 - apiVersion: v1
@@ -68,7 +68,7 @@ objects:
             value: ${SSO_ROUTE}
           - name: WALKTHROUGH_LOCATIONS
             value: ${WALKTHROUGH_LOCATIONS}
-          image: quay.io/integreatly/tutorial-web-app:master
+          image: quay.io/integreatly/tutorial-web-app:v2.1.0
           imagePullPolicy: Always
           name: tutorial-web-app
           ports:


### PR DESCRIPTION
**What**

Adds a default value for the WALKTHROUGH_LOCATIONS param in order to allow the operator to work without having to specify a walkthroughs location in the CR.

Set the webapp(v2.1.0) and walkthroughs(v1.1.0) default versions in the webapp operator template. These should be updated on master whenever a new version of either becomes available. 

**Jira:**

https://issues.jboss.org/browse/INTLY-464