### PR TITLE
make integreatly version available to webapp

### DIFF
--- a/deploy/template/tutorial-web-app.yml
+++ b/deploy/template/tutorial-web-app.yml
@@ -68,6 +68,8 @@ objects:
             value: ${SSO_ROUTE}
           - name: WALKTHROUGH_LOCATIONS
             value: ${WALKTHROUGH_LOCATIONS}
+          - name: INTEGREATLY_VERSION
+            value: ${INTEGREATLY_VERSION}
           image: quay.io/integreatly/tutorial-web-app:2.10.3
           imagePullPolicy: Always
           name: tutorial-web-app

--- a/pkg/handlers/webhandler.go
+++ b/pkg/handlers/webhandler.go
@@ -20,12 +20,14 @@ import (
 )
 
 const (
-	WebappVersion      = "master"
-	WTLocations        = "WALKTHROUGH_LOCATIONS"
-	WTLocationsDefault = "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.6.4"
+	WebappVersion             = "master"
+	WTLocations               = "WALKTHROUGH_LOCATIONS"
+	IntegreatlyVersion        = "INTEGREATLY_VERSION"
+	WTLocationsDefault        = "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.6.4"
+	IntegreatlyVersionDefault = "not set"
 )
 
-var webappParams = [...]string{"OPENSHIFT_OAUTHCLIENT_ID", "OPENSHIFT_HOST", "SSO_ROUTE", WTLocations}
+var webappParams = [...]string{"OPENSHIFT_OAUTHCLIENT_ID", "OPENSHIFT_HOST", "SSO_ROUTE", IntegreatlyVersion, WTLocations}
 
 func NewWebHandler(m *metrics.Metrics, osClient openshift.OSClientInterface, factory ClientFactory, cruder SdkCruder) AppHandler {
 	return AppHandler{
@@ -105,6 +107,8 @@ func (h *AppHandler) reconcile(cr *v1alpha1.WebApp) error {
 			// if WALKTHROUGH_LOCATIONS is not defined then use the default value
 			if param == WTLocations {
 				updated, dc.Spec.Template.Spec.Containers[0] = updateOrCreateEnvVar(dc.Spec.Template.Spec.Containers[0], param, WTLocationsDefault)
+			} else if param == IntegreatlyVersion {
+				updated, dc.Spec.Template.Spec.Containers[0] = updateOrCreateEnvVar(dc.Spec.Template.Spec.Containers[0], param, IntegreatlyVersionDefault)
 			} else {
 				//key does not exist in CR, ensure it is not present in the DC
 				updated, dc.Spec.Template.Spec.Containers[0] = deleteEnvVar(dc.Spec.Template.Spec.Containers[0], param)


### PR DESCRIPTION
Expose integreatly version to webapp as env var

Verification steps:

1. build an image from this branch and deploy it to an Integreatly cluster
1. wait for the operator and webapp to redeploy
1. check the environment variables of the webapp: there should be `INTEGREATLY_VERSION: not set`
1. Edit the `Web App` custom resource and add `INTEGREATLY_VERSION: master` to the params.
1. Wait for the webapp to redeploy and check the env vars again. The version should now say `master`