### PR TITLE
[INTLY-2308] - bump walkthroughs version

### DIFF
--- a/deploy/template/tutorial-web-app.yml
+++ b/deploy/template/tutorial-web-app.yml
@@ -29,7 +29,7 @@ parameters:
     required: false
   - name: WALKTHROUGH_LOCATIONS
     description: A comma separated list of git repositories or paths to walkthrough directories
-    value: https://github.com/integr8ly/tutorial-web-app-walkthroughs.git#v1.6.4
+    value: https://github.com/integr8ly/tutorial-web-app-walkthroughs.git#v1.6.5
     required: true
   - name: DATABASE_LOCATION
     description: The location of the user walkthroughs database in the filesystem


### PR DESCRIPTION
@finp can you confirm what the new walkthroughs tag will be? I've assumed 1.6.5 for now.