### PR TITLE
INTLY 7044 Added RoutingSubdomain and InstallationType as envars

### DIFF
--- a/deploy/template/tutorial-web-app.yml
+++ b/deploy/template/tutorial-web-app.yml
@@ -52,6 +52,9 @@ parameters:
   - name: INSTALLED_SERVICES
     description: Object which contains information on the services installed by Integreatly. Only used for OpenShift V4
     required: false
+  - name: INSTALLATION_TYPE
+    description: Type of cluster
+    required: false
 objects:
   - apiVersion: v1
     kind: DeploymentConfig
@@ -109,6 +112,8 @@ objects:
                   value: ${DATABASE_LOCATION}
                 - name: INSTALLED_SERVICES
                   value: ${INSTALLED_SERVICES}
+                - name: INSTALLATION_TYPE
+                  value: ${INSTALLATION_TYPE}
               image: quay.io/integreatly/tutorial-web-app:2.22.6
               imagePullPolicy: Always
               name: tutorial-web-app

--- a/pkg/handlers/webhandler.go
+++ b/pkg/handlers/webhandler.go
@@ -31,7 +31,6 @@ const (
 	OpenShiftAPIHost          = "OPENSHIFT_API"
 	InstalledServices         = "INSTALLED_SERVICES"
 	InstallationType          = "INSTALLATION_TYPE"
-	RoutingSubdomain          = "ROUTING_SUBDOMAIN"
 	WTLocationsDefault        = "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.12.1"
 	IntegreatlyVersionDefault = "not set"
 	ClusterTypeDefault        = "not set"
@@ -252,7 +251,7 @@ func (h *AppHandler) CreateRoute(cr *v1alpha1.WebApp) *routev1.Route {
 			},
 		},
 	}
-	subdomain := cr.Spec.Template.Parameters[RoutingSubdomain]
+	subdomain := cr.Spec.Template.Parameters["ROUTING_SUBDOMAIN"]
 
 	// Only set the host when the routing subdomain is set (RHMI 2.x). In 1.x we want to
 	// make sure to not change the existing route hosts because the cluster CORS settings

--- a/pkg/handlers/webhandler.go
+++ b/pkg/handlers/webhandler.go
@@ -30,6 +30,8 @@ const (
 	OpenShiftVersion          = "OPENSHIFT_VERSION"
 	OpenShiftAPIHost          = "OPENSHIFT_API"
 	InstalledServices         = "INSTALLED_SERVICES"
+	InstallationType          = "INSTALLATION_TYPE"
+	RoutingSubdomain          = "ROUTING_SUBDOMAIN"
 	WTLocationsDefault        = "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.12.1"
 	IntegreatlyVersionDefault = "not set"
 	ClusterTypeDefault        = "not set"
@@ -40,7 +42,7 @@ const (
 	routeName                 = "tutorial-web-app"
 )
 
-var webappParams = [...]string{"OPENSHIFT_OAUTHCLIENT_ID", "OPENSHIFT_HOST", "OPENSHIFT_OAUTH_HOST", "SSO_ROUTE", OpenShiftAPIHost, OpenShiftVersion, IntegreatlyVersion, WTLocations, ClusterType, InstalledServices}
+var webappParams = [...]string{"OPENSHIFT_OAUTHCLIENT_ID", "OPENSHIFT_HOST", "OPENSHIFT_OAUTH_HOST", "SSO_ROUTE", OpenShiftAPIHost, OpenShiftVersion, IntegreatlyVersion, WTLocations, ClusterType, InstalledServices, InstallationType}
 
 func NewWebHandler(m *metrics.Metrics, osClient openshift.OSClientInterface, factory ClientFactory, cruder SdkCruder) AppHandler {
 	return AppHandler{
@@ -250,7 +252,7 @@ func (h *AppHandler) CreateRoute(cr *v1alpha1.WebApp) *routev1.Route {
 			},
 		},
 	}
-	subdomain := cr.Spec.Template.Parameters["ROUTING_SUBDOMAIN"]
+	subdomain := cr.Spec.Template.Parameters[RoutingSubdomain]
 
 	// Only set the host when the routing subdomain is set (RHMI 2.x). In 1.x we want to
 	// make sure to not change the existing route hosts because the cluster CORS settings


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/INTLY-7044

## Verification
- Clone this repo
- Log into test cluster
- Run `make cluster/prepare`
- Run `make cluster/deploy`
- Add `INSTALLATION_TYPE` to `spec.Parameters` in the `WebApp` CR 
- Verify that `INSTALLATION_TYPE` and your supplied value is added to the `tutorial-web-app` pod