### PR TITLE
INTLY-7887 Add UPGRADE_DATA parameter to webhandler

### DIFF
--- a/pkg/handlers/webhandler.go
+++ b/pkg/handlers/webhandler.go
@@ -39,9 +39,10 @@ const (
 	WebAppImage               = "quay.io/integreatly/tutorial-web-app:2.25.1"
 	serviceName               = "tutorial-web-app"
 	routeName                 = "tutorial-web-app"
+	upgradeData               = "UPGRADE_DATA"
 )
 
-var webappParams = [...]string{"OPENSHIFT_OAUTHCLIENT_ID", "OPENSHIFT_HOST", "OPENSHIFT_OAUTH_HOST", "SSO_ROUTE", OpenShiftAPIHost, OpenShiftVersion, IntegreatlyVersion, WTLocations, ClusterType, InstalledServices, InstallationType}
+var webappParams = [...]string{"OPENSHIFT_OAUTHCLIENT_ID", "OPENSHIFT_HOST", "OPENSHIFT_OAUTH_HOST", "SSO_ROUTE", OpenShiftAPIHost, OpenShiftVersion, IntegreatlyVersion, WTLocations, ClusterType, InstalledServices, InstallationType, upgradeData}
 
 func NewWebHandler(m *metrics.Metrics, osClient openshift.OSClientInterface, factory ClientFactory, cruder SdkCruder) AppHandler {
 	return AppHandler{


### PR DESCRIPTION
# Description

> * Link to JIRA: https://issues.redhat.com/browse/INTLY-7887
> * Link to integreatly-operator PR: https://github.com/integr8ly/integreatly-operator/pull/867

Add UPGRADE_DATA parameter, which is reconciled by the RHMI operator with a JSON encoded object including data about an incoming upgrade, or `null` if there's no upgrade.

The object has the following format:

```json
{
  "scheduledFor": "string",
  "isServiceAffecting": "boolean",
  "version": "string"
}
```